### PR TITLE
fix(curl command): Add HTTP/1.1 option to curl command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+TBD
+====
+
+Add the --http1.1 option to the curl command to force use of HTTP/1.1 to
+prevent the uploads of larger files from failing.
+
 2.0.1 (04 Dec 2018)
 =====
 

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -28,7 +28,7 @@ fork do
   require 'shellwords'
 
   Dir["#{ENV["DWARF_DSYM_FOLDER_PATH"]}/*/Contents/Resources/DWARF/*"].each do |dsym|
-    curl_command = "curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV["PROJECT_DIR"])} "
+    curl_command = "curl --http1.1 -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV["PROJECT_DIR"])} "
     curl_command += "-F apiKey=#{Shellwords.escape(api_key)} " if api_key
     curl_command += "https://upload.bugsnag.com/"
     system(curl_command)


### PR DESCRIPTION
## Goal
Add the `--http1.1` option to the `curl` command to force use of HTTP/1.1

## Changeset
Change to `curl` command in `lib/cocoapods_bugsnag.rb`

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

### Linked issues
Fixes https://github.com/bugsnag/cocoapods-bugsnag/issues/7

## Review
For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
