### PR TITLE
feat: add bugsnag-cocoa v6 plist location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+TBD
+====
+
+Added new location for API key in `Info.plist` from
+[bugsnag-cocoa v6.x](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.0.0).
+
 2.0.1 (04 Dec 2018)
 =====
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # cocoapods-bugsnag
 
 A [CocoaPods](https://cocoapods.org) plugin for integrating Cocoa projects with
-[Bugsnag](https://bugsnag.com), an error tracking and resolution tool.
+[Bugsnag](https://bugsnag.com), an error tracking and resolution tool. When
+installed, the plugin will add a Run Script build phase to your project workspace
+to upload your
+[dSYM](http://noverse.com/blog/2010/03/how-to-deal-with-an-iphone-crash-report/)
+files so the Bugsnag service can provide you with symbolicated stack traces.
 
 ## Installation
 
@@ -20,17 +24,20 @@ install, run:
 
 ## Usage
 
-1. Add `pod 'Bugsnag'` to your Podfile
-2. Run `pod install`. This will add a Run Script build phase to your project
-   workspace to upload your
-   [dSYM](http://noverse.com/blog/2010/03/how-to-deal-with-an-iphone-crash-report/)
-   files so the Bugsnag service can provide you with symbolicated stack traces.
-3. Insert your API key in the new "Upload Bugsnag dSYM" run script build phase
-   in your project
+To add the build phase to your project, add pod ‘Bugsnag’ to your Podfile and run:
 
+```bash
+pod install
+```
+
+By default, your Bugsnag API key will either be read from the `BUGSNAG_API_KEY`
+environment variable or from the `:bugsnag:apiKey` (or `BugsnagAPIKey`) value in your
+`Info.plist`. Alternatively edit the script in the new "Upload Bugsnag dSYM" build 
+phase in Xcode.
 
 ## Support
 
+* [Symbolication guide](https://docs.bugsnag.com/platforms/ios/symbolication-guide/)
 * [Search open and closed issues](https://github.com/bugsnag/cocoapods-bugsnag/issues?utf8=✓&q=is%3Aissue)
   for similar problems
 * [Open an issue](https://github.com/bugsnag/cocoapods-bugsnag/issues/new)

--- a/cocoapods-bugsnag.gemspec
+++ b/cocoapods-bugsnag.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
 
   spec.add_dependency "cocoapods", "~> 1.0"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "bacon"
+  spec.add_development_dependency "rake", "~> 11.0"
+  spec.add_development_dependency "bacon", "~> 1.0"
 end

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -11,9 +11,9 @@ unless api_key
 
   # If not present, attempt to lookup the value from the Info.plist
   unless api_key
-default_info_plist_location = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /\/(build|test)\//i }
-    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :bugsnag:apiKey" "#{default_info_plist_location.first}"`
-    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{default_info_plist_location.first}"` if !$?.success?
+    info_plist_path = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /\/(build|test)\//i }.first
+    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :bugsnag:apiKey" "#{info_plist_path}"`
+    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{info_plist_path}"` if !$?.success?
     api_key = plist_buddy_response if $?.success?
   end
 end
@@ -30,7 +30,7 @@ fork do
 
   Dir["#{ENV["DWARF_DSYM_FOLDER_PATH"]}/*/Contents/Resources/DWARF/*"].each do |dsym|
     curl_command = "curl --http1.1 -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV["PROJECT_DIR"])} "
-    curl_command += "-F apiKey=#{Shellwords.escape(api_key)} " if api_key
+    curl_command += "-F apiKey=#{Shellwords.escape(api_key)} "
     curl_command += "https://upload.bugsnag.com/"
     system(curl_command)
   end

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -12,7 +12,8 @@ unless api_key
   # If not present, attempt to lookup the value from the Info.plist
   unless api_key
     default_info_plist_location = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }
-    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{default_info_plist_location.first}"`
+    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :bugsnag:apiKey" "#{default_info_plist_location.first}"`
+    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{default_info_plist_location.first}"` if !$?.success?
     api_key = plist_buddy_response if $?.success?
   end
 end


### PR DESCRIPTION
## Goal

With the release of [bugsnag-cocoa](https://github.com/bugsnag-cocoa) v6, users may set their API key in their `Info.plist` file under `:bugsnag:apiKey`. Added this location to the existing plist key, which is used for [bugsnag-react-native](https://github.com/bugsnag-react-native).

## Changeset

### Changed

* cocoapods_bugsnag.rb - added additional location and made original location (BugsnagAPIKey) a fallback.
* README.md - updated to describe the new usage
* cocoapods-bugsnag.gemspec - included lower bound of "rake" and "bacon" dependencies as per gem build warning.

## Tests

Manual testing in Xcode.
