### PR TITLE
fix: fix plist filter to allow paths with test/build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+TBD
+====
+
+Amended filter on `Info.plist` search so that it only removes files inside
+`/build/` or `/test/` directories rather than directories with the string
+"build" or "test" in them.
+
 2.0.1 (04 Dec 2018)
 =====
 

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -11,7 +11,7 @@ unless api_key
 
   # If not present, attempt to lookup the value from the Info.plist
   unless api_key
-    default_info_plist_location = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }
+    default_info_plist_location = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /\/(build|test)\//i }
     plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{default_info_plist_location.first}"`
     api_key = plist_buddy_response if $?.success?
   end


### PR DESCRIPTION
## Goal

The regex for filtering the Info.plist files found currently excludes any path with "build" or "test" in it. Added path separators to regex to ensure this only excludes /build or /test directories.

