### PR TITLE
Revert "fix: fix plist filter to allow paths with test/build"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.0 (25 Jun 2020)
+## 2.1.0 (TBD)
 
 ### Enhancements
 
@@ -11,8 +11,6 @@
 
 * Add the --http1.1 option to the curl command to force use of HTTP/1.1 to prevent the uploads of larger files from failing.
   | [#8](https://github.com/bugsnag/cocoapods-bugsnag/pull/8)
-* Amended filter on `Info.plist` search so that it only removes files inside `/build/` or `/test/` directories rather than directories with the string "build" or "test" in them.
-  | [#10](https://github.com/bugsnag/cocoapods-bugsnag/pull/10)
 
 ## 2.0.1 (04 Dec 2018)
 

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -11,7 +11,7 @@ unless api_key
 
   # If not present, attempt to lookup the value from the Info.plist
   unless api_key
-    info_plist_path = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /\/(build|test)\//i }.first
+    info_plist_path = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }.first
     plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :bugsnag:apiKey" "#{info_plist_path}"`
     plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{info_plist_path}"` if !$?.success?
     api_key = plist_buddy_response if $?.success?


### PR DESCRIPTION
## Goal

Reverts #10 to avoid a major change in functionality when locating `plist` files.

## Tests

Tested locally to ensure `plist` file is still picked up if the path doesn't include "test" or "build" (as before).