### PR TITLE
Get Info.plist path from the right location

### DIFF
--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -11,7 +11,7 @@ unless api_key
 
   # If not present, attempt to lookup the value from the Info.plist
   unless api_key
-    info_plist_path = Dir.glob("./{ios/,}*/Info.plist").reject {|path| path =~ /build|test/i }.first
+    info_plist_path = "#{ENV["BUILT_PRODUCTS_DIR"]}/#{ENV["INFOPLIST_PATH"]}"
     plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :bugsnag:apiKey" "#{info_plist_path}"`
     plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{info_plist_path}"` if !$?.success?
     api_key = plist_buddy_response if $?.success?


### PR DESCRIPTION
## Goal

The glob the plugin currently uses to find the Info.plist doesn't work for all projects

## Design

This approach uses environment variables that Xcode sets, guaranteeing that the plugin will find and use the correct Info.plist

## Changeset

Changed where the build phase script was looking for the Info.plist

## Testing

Pointed my own project to the fork, ran `bundle install && pod install`. Build succeeded instead of failing because it couldn't find the Info.plist.