### PR TITLE
Only add run script build phase if plugin is listed in Podfile

### DIFF
--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -40,7 +40,7 @@ RUBY
     alias_method :integrate_without_bugsnag!, :integrate!
     def integrate!
       integrate_without_bugsnag!
-      return unless has_bugsnag_dependency?
+      return unless should_add_build_phase?
       return if bugsnag_native_targets.empty?
       UI.section("Integrating with Bugsnag") do
         add_bugsnag_upload_script_phase
@@ -62,10 +62,14 @@ RUBY
       end
     end
 
-    def has_bugsnag_dependency?
-      target.target_definition.dependencies.detect do |dep|
+    def should_add_build_phase?
+      has_bugsnag_dep = target.target_definition.dependencies.any? do |dep|
         dep.name.include?('Bugsnag')
-      end != nil
+      end
+
+      uses_bugsnag_plugin = target.target_definition.podfile.plugins.key?('cocoapods-bugsnag')
+
+      return has_bugsnag_dep && uses_bugsnag_plugin
     end
 
     def bugsnag_native_targets


### PR DESCRIPTION
## Goal

Currently, the Run Script build phase is automatically added if the `Podfile` has a dependency on `Bugsnag`, even if the plugin hasn't been explicitly declared. This is different than how CocoaPods plugins usually behave. The goal is to fix this behavior, which was first reported back in 2016 in #2.

## Design

This matches the approach of other CocoaPods plugins like [cocoapods-amicable](https://github.com/segiddins/cocoapods-amicable/blob/master/lib/cocoapods_amicable.rb#L7).

## Changeset

* Modified `has_bugsnag_dependency?` to look for a `cocoapods-bugsnag` plugin declaration in addition to the `Bugsnag` pod dependency
* Renamed `has_bugsnag_dependency?` to `should_add_build_phase?` to reflect the change in behavior

## Testing

Pointed my project to the fork, ran bundle install, and ran pod install. Run Script build phase was only added if `plugin` declaration existed