### PR TITLE
[fix] new release of plugin following PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.0 (30 Sept 2020)
+
+### Enhancements
+
+* This plugin now finds `Info.plist` using Xcode environment variables, rather than a `glob` operation for robustness.
+  | [#15](https://github.com/bugsnag/cocoapods-bugsnag/pull/15)
+
+* This plugin will now only add itself to your Xcode project if it is explicitly added as a plugin in your `Podfile`. Previously it would install if `Bugsnag` was detected in your `Podfile`.
+  | [#16](https://github.com/bugsnag/cocoapods-bugsnag/pull/16)
+
 ## 2.1.0 (14 Aug 2020)
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -24,14 +24,23 @@ install, run:
 
 ## Usage
 
-To add the build phase to your project, add pod ‘Bugsnag’ to your Podfile and run:
+To add the build phase to your project, add `pod 'Bugsnag'`, and `plugin 'cocoapods-bugsnag'` to your `Podfile`:
+
+```ruby
+pod 'Bugsnag'
+plugin 'cocoapods-bugsnag'
+```
+
+Then, install with: 
 
 ```bash
 pod install
 ```
 
+Once added, uploading your dSYM files to Bugsnag will occur automatically.
+
 By default, your Bugsnag API key will either be read from the `BUGSNAG_API_KEY`
-environment variable or from the `:bugsnag:apiKey` (or `BugsnagAPIKey`) value in your
+environment variable or from the `bugsnag.apiKey` (or `BugsnagAPIKey`) value in your
 `Info.plist`. Alternatively edit the script in the new "Upload Bugsnag dSYM" build 
 phase in Xcode.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pod install
 Once added, uploading your dSYM files to Bugsnag will occur automatically.
 
 By default, your Bugsnag API key will either be read from the `BUGSNAG_API_KEY`
-environment variable or from the `bugsnag.apiKey` (or `BugsnagAPIKey`) value in your
+environment variable or from the `:bugsnag:apiKey` (or `BugsnagAPIKey`) value in your
 `Info.plist`. Alternatively edit the script in the new "Upload Bugsnag dSYM" build 
 phase in Xcode.
 

--- a/cocoapods-bugsnag.gemspec
+++ b/cocoapods-bugsnag.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = "cocoapods-bugsnag"
-  spec.version = "2.1.0"
+  spec.version = "2.2.0"
   spec.homepage = "https://bugsnag.com"
   spec.description = "Configures the dSYM upload phase of your project when integrated with bugsnag."
   spec.summary = "To get meaningful stacktraces from your crashes, the Bugsnag service needs your dSYM file for your build. This plugin adds an upload phase to your project where needed."

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -66,9 +66,7 @@ RUBY
       has_bugsnag_dep = target.target_definition.dependencies.any? do |dep|
         dep.name.include?('Bugsnag')
       end
-
       uses_bugsnag_plugin = target.target_definition.podfile.plugins.key?('cocoapods-bugsnag')
-
       return has_bugsnag_dep && uses_bugsnag_plugin
     end
 


### PR DESCRIPTION
## Goal
Following two PRs from @sethfri: https://github.com/bugsnag/cocoapods-bugsnag/pull/15 and https://github.com/bugsnag/cocoapods-bugsnag/pull/16, this PR addresses changes required to release this update

## Changeset
* `README.md` (updated usage)
* `CHANGELOG.md` (changes listed)
* `cocoapods-bugsnag.gemspec` (bumped version)