### PR TITLE
Specify input files for compatibility with Xcode new build system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* The Xcode build phase now specifies its dependencies for improved reliability with Xcode's new build system.
+  | [#20](https://github.com/bugsnag/cocoapods-bugsnag/pull/20)
+
 ## 2.2.0 (30 Sept 2020)
 
 ### Enhancements

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -2,6 +2,10 @@ module Pod
   class Installer::UserProjectIntegrator::TargetIntegrator
 
     BUGSNAG_PHASE_NAME = "Upload Bugsnag dSYM"
+    BUGSNAG_PHASE_INPUT_PATHS = [
+      "${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}",
+      "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}"]
+    BUGSNAG_PHASE_SHELL_PATH = "/usr/bin/env ruby"
     BUGSNAG_PHASE_SCRIPT = <<'RUBY'
 api_key = nil # Insert your key here to use it directly from this script
 
@@ -56,10 +60,8 @@ RUBY
           bp.name == BUGSNAG_PHASE_NAME
         end.first || native_target.new_shell_script_build_phase(BUGSNAG_PHASE_NAME)
 
-        phase.input_paths = [
-          "${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}",
-          "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}"]
-        phase.shell_path = "/usr/bin/env ruby"
+        phase.input_paths = BUGSNAG_PHASE_INPUT_PATHS
+        phase.shell_path = BUGSNAG_PHASE_SHELL_PATH
         phase.shell_script = BUGSNAG_PHASE_SCRIPT
         phase.show_env_vars_in_log = '0'
       end
@@ -77,7 +79,7 @@ RUBY
       @bugsnag_native_targets ||=(
         native_targets.reject do |native_target|
           native_target.shell_script_build_phases.any? do |bp|
-            bp.name == BUGSNAG_PHASE_NAME && bp.shell_script == BUGSNAG_PHASE_SCRIPT
+            bp.name == BUGSNAG_PHASE_NAME && bp.input_paths == BUGSNAG_PHASE_INPUT_PATHS && bp.shell_path == BUGSNAG_PHASE_SHELL_PATH && bp.shell_script == BUGSNAG_PHASE_SCRIPT
           end
         end
       )

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -56,6 +56,9 @@ RUBY
           bp.name == BUGSNAG_PHASE_NAME
         end.first || native_target.new_shell_script_build_phase(BUGSNAG_PHASE_NAME)
 
+        phase.input_paths = [
+          "${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}",
+          "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}"]
         phase.shell_path = "/usr/bin/env ruby"
         phase.shell_script = BUGSNAG_PHASE_SCRIPT
         phase.show_env_vars_in_log = '0'


### PR DESCRIPTION
## Goal

It was found that uploading dSYMs with recent versions of Xcode was not reliable; the first clean build of the example project was failing to upload dYSMs as the upload symbols build phase was being run before Xcode had written the dSYM file.

The [Xcode 10 release notes](https://developer.apple.com/documentation/xcode-release-notes/build-system-release-notes-for-xcode-10#New-Features) state:

> In the new build system, shell scripts can’t rely on the state of build artifacts not listed in other build phases (for example, the Info.plist file or .dSYM files.) Add files the script build phase depends on as explicit input dependencies to the shell script build phase. (40852184)

## Changeset

The [input_paths](https://www.rubydoc.info/gems/xcodeproj/Xcodeproj/Project/Object/PBXShellScriptBuildPhase#input_paths-instance_method) property is now being set.

## Testing

Manually verified by building and running the plugin.

Users do not need to delete their existing build phase, after updating cocoapods-bugsnag and running `pod install` their build phase will be updated.