### PR TITLE
bugsnag_flutter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ pod install
 Once added, uploading your dSYM files to Bugsnag will occur automatically.
 
 By default, your Bugsnag API key will either be read from the `BUGSNAG_API_KEY`
-environment variable or from the `:bugsnag:apiKey` (or `BugsnagAPIKey`) value in your
-`Info.plist`. Alternatively edit the script in the new "Upload Bugsnag dSYM" build 
-phase in Xcode.
+environment variable (add an Xcode build setting with this name to set it) or
+from the `:bugsnag:apiKey` (or `BugsnagAPIKey`) value in your `Info.plist`.
 
 Uploading can be disabled by setting `DISABLE_COCOAPODS_BUGSNAG=YES` in Xcode's
 Build Settings or an `xcconfig` file, or as an argument to `xcodebuild`.

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -13,19 +13,15 @@ if ENV['DISABLE_COCOAPODS_BUGSNAG'] == 'YES'
   return
 end
 
-api_key = nil # Insert your key here to use it directly from this script
+# Attempt to get the API key from an environment variable (or Xcode build setting)
+api_key = ENV["BUGSNAG_API_KEY"]
 
-# Attempt to get the API key from an environment variable
+# If not present, attempt to lookup the value from the Info.plist
 unless api_key
-  api_key = ENV["BUGSNAG_API_KEY"]
-
-  # If not present, attempt to lookup the value from the Info.plist
-  unless api_key
-    info_plist_path = "#{ENV["BUILT_PRODUCTS_DIR"]}/#{ENV["INFOPLIST_PATH"]}"
-    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :bugsnag:apiKey" "#{info_plist_path}"`
-    plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{info_plist_path}"` if !$?.success?
-    api_key = plist_buddy_response if $?.success?
-  end
+  info_plist_path = "#{ENV["BUILT_PRODUCTS_DIR"]}/#{ENV["INFOPLIST_PATH"]}"
+  plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :bugsnag:apiKey" "#{info_plist_path}"`
+  plist_buddy_response = `/usr/libexec/PlistBuddy -c "print :BugsnagAPIKey" "#{info_plist_path}"` if !$?.success?
+  api_key = plist_buddy_response if $?.success?
 end
 
 fail("No Bugsnag API key detected - add your key to your Info.plist, BUGSNAG_API_KEY environment variable or this Run Script phase") unless api_key

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -75,7 +75,7 @@ RUBY
 
     def should_add_build_phase?
       has_bugsnag_dep = target.target_definition.dependencies.any? do |dep|
-        dep.name.include?('Bugsnag')
+        dep.name.match?(/bugsnag/i)
       end
       uses_bugsnag_plugin = target.target_definition.podfile.plugins.key?('cocoapods-bugsnag')
       return has_bugsnag_dep && uses_bugsnag_plugin


### PR DESCRIPTION
## Goal

Allow use with Flutter projects that use [bugsnag_flutter](https://github.com/bugsnag/bugsnag-flutter)

## Changeset

Makes the dependency name check case insensitive so it works with `bugsnag_flutter`.

Removes the _"Insert your key here to use it directly from this script"_ comment and instructions since user edits to the build phase are clobbered when the plugin next runs.

## Testing

Performed manual testing with a sample Flutter project.