### PR TITLE
[PLAT-8800] Add support for ENABLE_USER_SCRIPT_SANDBOXING

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,31 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--require spec_helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* The Xcode build phase is now compatible with Xcode 14's `ENABLE_USER_SCRIPT_SANDBOXING` build setting.
+  This requires all dSYM files to be specified in the build phase's "Input Files" list.
+  | [#28](https://github.com/bugsnag/cocoapods-bugsnag/pull/28)
+
 ## 2.2.2 (17 May 2022)
 
 ### Enhancements

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,17 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec
+
+def cocoapods_gem(name, gem_name = name.downcase, **opts)
+  gem gem_name, git: "https://github.com/CocoaPods/#{name}", **opts
+end
+
+group :development do
+  cocoapods_gem 'CocoaPods'
+  cocoapods_gem 'Core', 'cocoapods-core'
+  cocoapods_gem 'Xcodeproj'
+
+  gem 'rspec'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
+task default: %i[spec]
 
 task :spec do
-  sh 'bundle exec bacon spec/*_spec.rb'
+  sh 'bundle exec rspec'
 end

--- a/cocoapods-bugsnag.gemspec
+++ b/cocoapods-bugsnag.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "cocoapods", "~> 1.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "bacon", "~> 1.0"
 end

--- a/spec/cocoapods_bugsnag_spec.rb
+++ b/spec/cocoapods_bugsnag_spec.rb
@@ -1,3 +1,128 @@
-require 'bacon'
+# frozen_string_literal: true
 
+require 'cocoapods'
+require 'cocoapods_bugsnag'
+require 'tmpdir'
 
+# rubocop:disable Lint/MissingCopEnableDirective, Metrics/BlockLength
+
+RSpec.describe 'cocoapods-bugsnag' do
+  context 'with a user project' do
+    around(:each) do |t|
+      Dir.chdir(Dir.mktmpdir) { t.run }
+    end
+
+    let(:config) { Pod::Config.instance }
+
+    before do
+      user_project = Xcodeproj::Project.new('App.xcodeproj')
+      Pod::Generator::AppTargetHelper.add_app_target(user_project, :osx, '10.11')
+      user_project.save
+
+      CLAide::Command::PluginManager.load_plugins('cocoapods')
+    end
+
+    it 'adds a build phase if included in Podfile' do
+      File.write 'Podfile', <<~RUBY
+        use_frameworks!
+        plugin 'cocoapods-bugsnag'
+        target 'App' do
+          pod 'AFNetworking'
+          pod 'Bugsnag'
+        end
+      RUBY
+
+      installer = Pod::Installer.new(config.sandbox, config.podfile, config.lockfile)
+      installer.install!
+
+      expect(Pod::UI.output).to include "Adding 'Upload Bugsnag dSYM' build phase to 'App'"
+
+      expect(installer.aggregate_targets.flat_map(&:user_targets)).to all(satisfy do |target|
+        upload_phase = target.shell_script_build_phases.find { |bp| bp.name == 'Upload Bugsnag dSYM' }
+        expect(upload_phase.shell_path).to eq '/usr/bin/env ruby'
+        expect(upload_phase.shell_script).to include 'BUGSNAG_API_KEY'
+        expect(upload_phase.shell_script).to include 'SCRIPT_INPUT_FILE_COUNT'
+        expect(upload_phase.show_env_vars_in_log).to eq '0'
+        expect(upload_phase.input_paths).to eq %w[
+          ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}
+          ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
+          ${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework.dSYM/Contents/Resources/DWARF/AFNetworking
+          ${BUILT_PRODUCTS_DIR}/Bugsnag/Bugsnag.framework.dSYM/Contents/Resources/DWARF/Bugsnag
+        ]
+      end)
+    end
+
+    it 'does not remove existing input phases' do
+      File.write 'Podfile', <<~RUBY
+        use_frameworks!
+        plugin 'cocoapods-bugsnag'
+        target 'App' do
+          pod 'AFNetworking'
+          pod 'Bugsnag'
+        end
+      RUBY
+
+      installer = Pod::Installer.new(config.sandbox, config.podfile, config.lockfile)
+      installer.install!
+
+      expect(Pod::UI.output).to include "Adding 'Upload Bugsnag dSYM' build phase to 'App'"
+      Pod::UI.output = ''.dup
+
+      File.write 'Podfile', <<~RUBY
+        use_frameworks!
+        plugin 'cocoapods-bugsnag'
+        target 'App' do
+          # AFNetworking now omitted
+          pod 'Bugsnag'
+        end
+      RUBY
+
+      installer = Pod::Installer.new(config.sandbox, config.podfile, config.lockfile)
+      installer.install!
+
+      expect(Pod::UI.output).not_to include "Adding 'Upload Bugsnag dSYM' build phase to 'App'"
+
+      expect(installer.aggregate_targets.flat_map(&:user_targets)).to all(satisfy do |target|
+        upload_phase = target.shell_script_build_phases.find { |bp| bp.name == 'Upload Bugsnag dSYM' }
+        expect(upload_phase.input_paths).to include(
+          '${BUILT_PRODUCTS_DIR}/AFNetworking/AFNetworking.framework.dSYM/Contents/Resources/DWARF/AFNetworking'
+        )
+      end)
+    end
+
+    it 'does nothing if Bugsnag is not a dependency' do
+      File.write 'Podfile', <<~RUBY
+        plugin 'cocoapods-bugsnag'
+        target 'App'
+      RUBY
+
+      installer = Pod::Installer.new(config.sandbox, config.podfile, config.lockfile)
+      installer.install!
+
+      expect(Pod::UI.output).not_to include "Adding 'Upload Bugsnag dSYM' build phase to 'App'"
+
+      expect(installer.aggregate_targets.flat_map(&:user_targets)).to all(satisfy do |target|
+        upload_phase = target.shell_script_build_phases.find { |bp| bp.name == 'Upload Bugsnag dSYM' }
+        expect(upload_phase).to be_nil
+      end)
+    end
+
+    it 'does nothing if not added as a plugin' do
+      File.write 'Podfile', <<~RUBY
+        target 'App' do
+          pod 'Bugsnag'
+        end
+      RUBY
+
+      installer = Pod::Installer.new(config.sandbox, config.podfile, config.lockfile)
+      installer.install!
+
+      expect(Pod::UI.output).not_to include "Adding 'Upload Bugsnag dSYM' build phase to 'App'"
+
+      expect(installer.aggregate_targets.flat_map(&:user_targets)).to all(satisfy do |target|
+        upload_phase = target.shell_script_build_phases.find { |bp| bp.name == 'Upload Bugsnag dSYM' }
+        expect(upload_phase).to be_nil
+      end)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'cocoapods'
+
+module Pod
+  # Disable the wrapping so the output is deterministic in the tests.
+  #
+  UI.disable_wrap = true
+
+  # Redirects the messages to an internal store.
+  #
+  module UI
+    class << self
+      attr_accessor :output, :warnings, :next_input
+
+      def puts(message = '')
+        @output << "#{message}\n"
+      end
+
+      def warn(message = '', _actions = [])
+        @warnings << "#{message}\n"
+      end
+
+      def print(message)
+        @output << message
+      end
+
+      alias gets next_input
+
+      def print_warnings; end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:each) do
+    Pod::UI.output = ''.dup
+    Pod::UI.warnings = ''.dup
+    Pod::UI.next_input = ''.dup
+    Pod::Config.instance = nil
+  end
+end


### PR DESCRIPTION
## Goal

Make the "Upload Bugsnag dSYM" script compatible with Xcode 14's `ENABLE_USER_SCRIPT_SANDBOXING` build setting.

## Changeset

Updates `BUGSNAG_PHASE_SCRIPT` to mirror (as closely as possible) the updated script on https://docs.bugsnag.com/platforms/ios/symbolication-guide/#adding-a-build-phase-manually

Makes plugin add to `input_paths` rather than replacing user values.

Automatically adds dSYM `input_paths` for linked CocoaPods frameworks.

## Testing

Tested locally with sample projects.

* https://github.com/bugsnag/cocoapods-bugsnag/pull/29