### PR TITLE
Removing check to enable build logging output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* The Xcode build phase now outputs dSYM upload information to the Xcode build logs.
+  | [#31](https://github.com/bugsnag/cocoapods-bugsnag/pull/31)
+
 ## 2.3.0 (13 Sept 2022)
 
 ### Enhancements

--- a/lib/cocoapods_bugsnag.rb
+++ b/lib/cocoapods_bugsnag.rb
@@ -49,7 +49,6 @@ dsyms.each do |dsym|
     '-F', "dsym=@#{dsym}",
     '-F', "projectRoot=#{ENV['PROJECT_DIR']}",
     'https://upload.bugsnag.com/',
-    %i[err out] => :close
   )
 end
 RUBY


### PR DESCRIPTION
We can remove the `%i[err out] => :close` check from the Cocoapods dSYM upload script to make more information visible in the build logs regarding dSYM upload success and failures. 

This change has also been reflected in our [docs](https://docs.bugsnag.com/platforms/ios/symbolication-guide/#adding-a-build-phase-manually), with the check being removed from the manual dSYM upload script provided.

With this check removed, on a successful upload users should see something like this in their build logs:
![231491542-e932c596-611e-4317-b3ba-6b52382eb629](https://user-images.githubusercontent.com/113024072/233132642-c0b0d93d-4378-42c3-8a00-ed4e69324cfb.png)

In an unsuccessful upload users should see the error message outputed to the build logs:
<img width="519" alt="231491878-8cf48b93-2a72-4496-902a-dcadd8c5fb80" src="https://user-images.githubusercontent.com/113024072/233132719-cda88ea5-fe7d-49a2-b03a-c352e4944317.png">

## Changeset

The only changes made are to remove the line containing %i[err out] => :close. 

## Testing

This change was successfully tested in a new xcode project using a locally built version of this `cocoapods-bugsnag` branch.